### PR TITLE
Fix PR comments

### DIFF
--- a/contracts/Unibright.sol
+++ b/contracts/Unibright.sol
@@ -71,7 +71,7 @@ contract UBTSplitter is Context, Ownable {
     mapping(address => uint256) public ubtReleased;
     
     uint256 public ubtToBeReleasedInPeriod;
-    uint256 public ubtNotReleasedInLastPeriod;
+    uint256 public ubtNotReleasedInLastPeriods;
     uint256 public ubtCurrentPeriod;
 
     address public whitelistedToken;
@@ -149,7 +149,7 @@ contract UBTSplitter is Context, Ownable {
         );
    
         uint256 alreadyReceivedSinceLastPayeeUpdate = ubtReleasedPerRecipientInPeriods[ubtCurrentPeriod][msg.sender];
-        uint256 toBeReleased = ubtToBeReleasedInPeriod + ubtNotReleasedInLastPeriod;
+        uint256 toBeReleased = ubtToBeReleasedInPeriod + ubtNotReleasedInLastPeriods;
         uint256 payment = (shares[msg.sender] * toBeReleased) / totalShares - alreadyReceivedSinceLastPayeeUpdate;
 
         require(payment != 0, "msg.sender is not due payment");
@@ -256,6 +256,6 @@ contract UBTSplitter is Context, Ownable {
 
         ubtToBeReleasedInPeriod = 0;
         ubtCurrentPeriod += 1;
-        ubtNotReleasedInLastPeriod = IERC20(whitelistedToken).balanceOf(address(this));
+        ubtNotReleasedInLastPeriods = IERC20(whitelistedToken).balanceOf(address(this));
     }
 }

--- a/contracts/Unibright.sol
+++ b/contracts/Unibright.sol
@@ -142,28 +142,28 @@ contract UBTSplitter is Context, Ownable {
      * percentage of the total shares and their previous withdrawals. `token` must be the address of an IERC20
      * contract.
      */
-    function release(address revenueAddress) public virtual {
+    function release() public virtual {
         require(
-            shares[revenueAddress] > 0,
-            "revenueAddress has no shares"
+            shares[msg.sender] > 0,
+            "msg.sender has no shares"
         );
    
-        uint256 alreadyReceivedSinceLastPayeeUpdate = ubtReleasedPerRecipientInPeriods[ubtCurrentPeriod][revenueAddress];
+        uint256 alreadyReceivedSinceLastPayeeUpdate = ubtReleasedPerRecipientInPeriods[ubtCurrentPeriod][msg.sender];
         uint256 toBeReleased = ubtToBeReleasedInPeriod + ubtNotReleasedInLastPeriod;
-        uint256 payment = (shares[revenueAddress] * toBeReleased) / totalShares - alreadyReceivedSinceLastPayeeUpdate;
+        uint256 payment = (shares[msg.sender] * toBeReleased) / totalShares - alreadyReceivedSinceLastPayeeUpdate;
 
-        require(payment != 0, "revenueAddress is not due payment");
+        require(payment != 0, "msg.sender is not due payment");
 
-        ubtReleased[revenueAddress] += payment;
+        ubtReleased[msg.sender] += payment;
         ubtTotalReleased += payment;
         
-        ubtReleasedPerRecipientInPeriods[ubtCurrentPeriod][revenueAddress] += payment;
+        ubtReleasedPerRecipientInPeriods[ubtCurrentPeriod][msg.sender] += payment;
 
-        SafeERC20.safeTransfer(IERC20(whitelistedToken), revenueAddress, payment);
+        SafeERC20.safeTransfer(IERC20(whitelistedToken), msg.sender, payment);
         emit UbtPaymentReleased(
             IERC20(whitelistedToken),
-            revenueAddress,
-            validatorStakingAddress[revenueAddress],
+            msg.sender,
+            validatorStakingAddress[msg.sender],
             payment
         );
     }

--- a/contracts/Unibright.sol
+++ b/contracts/Unibright.sol
@@ -194,15 +194,8 @@ contract UBTSplitter is Context, Ownable {
         require(shares_ > 0, "shares are 0");
 
         payees[revenueAddress] = true;
-        validatorStakingAddress[revenueAddress] = stakingAddress;
-        shares[revenueAddress] = shares_;
-        totalShares = totalShares + shares_;
-        lastEventNonce = lastEventNonce + 1;
 
-        ubtToBeReleasedInPeriod = 0;
-        ubtCurrentPeriod += 1;
-        ubtNotReleasedInLastPeriod = IERC20(whitelistedToken).balanceOf(address(this));
-        
+        _updatePayeeSharesAndCurrentPeriod(revenueAddress, stakingAddress, shares_);
 
         emit PayeeAdded(
             revenueAddress,
@@ -239,14 +232,7 @@ contract UBTSplitter is Context, Ownable {
         );
         totalShares = totalShares - shares[revenueAddress]; // remove the current share of the account from total shares.
 
-        validatorStakingAddress[revenueAddress] = stakingAddress;
-        shares[revenueAddress] = shares_;
-        totalShares = totalShares + shares_; // add the new share of the account to total shares.
-        lastEventNonce = lastEventNonce + 1;
-
-        ubtToBeReleasedInPeriod = 0;
-        ubtCurrentPeriod += 1;
-        ubtNotReleasedInLastPeriod = IERC20(whitelistedToken).balanceOf(address(this));
+        _updatePayeeSharesAndCurrentPeriod(revenueAddress, stakingAddress, shares_);
 
         emit PayeeUpdated(
             revenueAddress,
@@ -256,5 +242,20 @@ contract UBTSplitter is Context, Ownable {
             lastEventNonce,
             block.timestamp
         );
+    }
+
+    function _updatePayeeSharesAndCurrentPeriod(
+        address revenueAddress,
+        address stakingAddress,
+        uint256 shares_
+    ) private {
+        validatorStakingAddress[revenueAddress] = stakingAddress;
+        shares[revenueAddress] = shares_;
+        totalShares = totalShares + shares_;
+        lastEventNonce = lastEventNonce + 1;
+
+        ubtToBeReleasedInPeriod = 0;
+        ubtCurrentPeriod += 1;
+        ubtNotReleasedInLastPeriod = IERC20(whitelistedToken).balanceOf(address(this));
     }
 }

--- a/contracts/Unibright.sol
+++ b/contracts/Unibright.sol
@@ -93,7 +93,7 @@ contract UBTSplitter is Context, Ownable {
      * @dev Modifier for checking for zero address
      */
     modifier zeroAddress(address token) {
-        require(token != address(0), "UBTSplitter: Address is zero address");
+        require(token != address(0), "address is zero address");
         _;
     }
 
@@ -104,7 +104,7 @@ contract UBTSplitter is Context, Ownable {
         bytes memory tempEmptyStringTest = bytes(baseledgervaloper);
         require(
             tempEmptyStringTest.length != 0,
-            "UBTSplitter: String is empty"
+            "string is empty"
         );
         _;
     }
@@ -120,7 +120,7 @@ contract UBTSplitter is Context, Ownable {
     ) public emptyString(baseledgerDestinationAddress) {
         require(
             amount > 0,
-            "UBTSplitter: amount should be grater than zero"
+            "amount should be grater than zero"
         );
         lastEventNonce = lastEventNonce + 1;
 
@@ -145,7 +145,7 @@ contract UBTSplitter is Context, Ownable {
     function release(address revenueAddress) public virtual {
         require(
             shares[revenueAddress] > 0,
-            "UBTSplitter: revenueAddress has no shares"
+            "revenueAddress has no shares"
         );
    
         uint256 alreadyReceivedSinceLastPayeeUpdate = ubtReleasedPerRecipientInPeriods[ubtCurrentPeriod][revenueAddress];
@@ -153,7 +153,7 @@ contract UBTSplitter is Context, Ownable {
         toBeReleased += ubtNotReleasedInLastPeriod;
         uint256 payment = (shares[revenueAddress] * toBeReleased) / totalShares - alreadyReceivedSinceLastPayeeUpdate;
 
-        require(payment != 0, "UBTSplitter: revenueAddress is not due payment");
+        require(payment != 0, "revenueAddress is not due payment");
 
         ubtReleased[revenueAddress] += payment;
         ubtTotalReleased += payment;
@@ -188,10 +188,10 @@ contract UBTSplitter is Context, Ownable {
         zeroAddress(stakingAddress)
         emptyString(baseledgervaloper)
     {
-        require(shares_ > 0, "UBTSplitter: shares are 0");
+        require(shares_ > 0, "shares are 0");
         require(
             shares[revenueAddress] == 0,
-            "UBTSplitter: revenueAddress already has shares"
+            "revenueAddress already has shares"
         );
 
         payees.push(revenueAddress);

--- a/contracts/Unibright.sol
+++ b/contracts/Unibright.sol
@@ -2,7 +2,7 @@
 // OpenZeppelin Contracts v4.4.1 (finance/UBTSplitter.sol)
 
 pragma solidity ^0.8.0;
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
@@ -144,12 +144,12 @@ contract UBTSplitter is Context, Ownable {
         uint256 toBeReleased = ubtToBeReleasedInPeriod + ubtNotReleasedInLastPeriods;
         uint256 payment = (shares[msg.sender] * toBeReleased) / totalShares - alreadyReceivedSinceLastPayeeUpdate;
 
-        require(payment != 0, "msg.sender is not due payment");
-        SafeERC20.safeTransfer(IERC20(whitelistedToken), msg.sender, payment);
-
         ubtReleased[msg.sender] += payment;
         ubtTotalReleased += payment;
         ubtReleasedPerRecipientInPeriods[ubtCurrentPeriod][msg.sender] += payment;
+
+        require(payment != 0, "msg.sender is not due payment");
+        IERC20(whitelistedToken).transfer(msg.sender, payment);
 
         emit UbtPaymentReleased(
             IERC20(whitelistedToken),

--- a/contracts/Unibright.sol
+++ b/contracts/Unibright.sol
@@ -65,7 +65,7 @@ contract UBTSplitter is Context, Ownable {
 
     mapping(address => uint256) public shares;
     mapping(address => address) public validatorStakingAddress; // revenueAddress => validatorStakingAddress
-    address[] public payees;
+    mapping(address => bool) public payees;
 
     uint256 public ubtTotalReleased;
     mapping(address => uint256) public ubtReleased;
@@ -149,8 +149,7 @@ contract UBTSplitter is Context, Ownable {
         );
    
         uint256 alreadyReceivedSinceLastPayeeUpdate = ubtReleasedPerRecipientInPeriods[ubtCurrentPeriod][revenueAddress];
-        uint256 toBeReleased = ubtToBeReleasedInPeriod;        
-        toBeReleased += ubtNotReleasedInLastPeriod;
+        uint256 toBeReleased = ubtToBeReleasedInPeriod + ubtNotReleasedInLastPeriod;
         uint256 payment = (shares[revenueAddress] * toBeReleased) / totalShares - alreadyReceivedSinceLastPayeeUpdate;
 
         require(payment != 0, "revenueAddress is not due payment");
@@ -194,7 +193,7 @@ contract UBTSplitter is Context, Ownable {
             "revenueAddress already has shares"
         );
 
-        payees.push(revenueAddress);
+        payees[revenueAddress] = true;
         validatorStakingAddress[revenueAddress] = stakingAddress;
         shares[revenueAddress] = shares_;
         totalShares = totalShares + shares_;
@@ -234,6 +233,10 @@ contract UBTSplitter is Context, Ownable {
         zeroAddress(stakingAddress)
         emptyString(baseledgervaloper)
     {
+        require(
+            payees[revenueAddress] == true,
+            "payee does not exist"
+        );
         totalShares = totalShares - shares[revenueAddress]; // remove the current share of the account from total shares.
 
         validatorStakingAddress[revenueAddress] = stakingAddress;

--- a/contracts/Unibright.sol
+++ b/contracts/Unibright.sol
@@ -187,11 +187,11 @@ contract UBTSplitter is Context, Ownable {
         zeroAddress(stakingAddress)
         emptyString(baseledgervaloper)
     {
-        require(shares_ > 0, "shares are 0");
         require(
-            shares[revenueAddress] == 0,
-            "revenueAddress already has shares"
+            payees[revenueAddress] == false,
+            "payee already exists"
         );
+        require(shares_ > 0, "shares are 0");
 
         payees[revenueAddress] = true;
         validatorStakingAddress[revenueAddress] = stakingAddress;

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,8 +1,8 @@
 import hre from "hardhat";
 import { ContractFactory } from "ethers";
-import { UBTSplitter } from "../typechain";
+import { BaseledgerUBTSplitter } from "../typechain";
 
-export async function deployContracts(whitelistedToken: string) {
+export async function deployContracts(ubtTokenContractAddress: string) {
   await hre.run("compile");
   const [deployer] = await hre.ethers.getSigners();
 
@@ -11,12 +11,14 @@ export async function deployContracts(whitelistedToken: string) {
     `Account balance: ${(await deployer.getBalance()).toString()} \n`
   );
 
-  const UBTSplitterFactory: ContractFactory =
-    await hre.ethers.getContractFactory("UBTSplitter");
+  const BaseledgerUBTSplitterFactory: ContractFactory =
+    await hre.ethers.getContractFactory("BaseledgerUBTSplitter");
 
-  const UBTSplitter = (await UBTSplitterFactory.deploy(
-    whitelistedToken
-  )) as UBTSplitter;
-  await UBTSplitter.deployed();
-  console.log(`Unibright contract deployed at: ${UBTSplitter.address}`);
+  const BaseledgerUBTSplitter = (await BaseledgerUBTSplitterFactory.deploy(
+    ubtTokenContractAddress
+  )) as BaseledgerUBTSplitter;
+  await BaseledgerUBTSplitter.deployed();
+  console.log(
+    `Unibright contract deployed at: ${BaseledgerUBTSplitter.address}`
+  );
 }

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -4,14 +4,14 @@ export async function verifyContracts(
   contractAddress: string,
   token: string
 ): Promise<void> {
-  // verify UBTSplitter contract
+  // verify BaseledgerUBTSplitter contract
   try {
     await hre.run("verify:verify", {
       address: contractAddress,
       constructorArguments: [token],
     });
   } catch (error: any) {
-    logError("UBTSplitter", error.message);
+    logError("BaseledgerUBTSplitter", error.message);
   }
 }
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -206,7 +206,7 @@ describe("UBTSplitter contract tests", () => {
           shares.fifty,
           baseledgervaloper
         )
-      ).to.be.revertedWith("revenueAddress already has shares");
+      ).to.be.revertedWith("payee already exists");
     });
 
     it("Should fail if malicious account tries to add validator ", async () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -76,7 +76,6 @@ describe("UBTSplitter contract tests", () => {
       expect(allowance).to.equal(tenTokens);
       expect(
         await UBTContract.connect(tokenSenderAccount).deposit(
-          ubtMockAddress,
           tenTokens,
           destinationAddress
         )
@@ -93,30 +92,15 @@ describe("UBTSplitter contract tests", () => {
       expect(contractBalance).to.equal(tenTokens);
     });
 
-    it("Should fail on transfer token with zero token address", async () => {
-      await expect(
-        UBTContract.connect(tokenSenderAccount).deposit(
-          zeroAddress,
-          tenTokens,
-          destinationAddress
-        )
-      ).to.be.revertedWith("UBTSplitter: Address is zero address");
-    });
-
     it("Should fail on transfer token with empty token destination address", async () => {
       await expect(
-        UBTContract.connect(tokenSenderAccount).deposit(
-          ubtMockAddress,
-          tenTokens,
-          ""
-        )
+        UBTContract.connect(tokenSenderAccount).deposit(tenTokens, "")
       ).to.be.revertedWith("UBTSplitter: String is empty");
     });
 
     it("Should fail on transfer zero token amount", async () => {
       await expect(
         UBTContract.connect(tokenSenderAccount).deposit(
-          ubtMockAddress,
           zeroToken,
           destinationAddress
         )
@@ -369,34 +353,33 @@ describe("UBTSplitter contract tests", () => {
         .approve(UBTAddress, tenTokens);
       await tx.wait();
       await UBTContract.connect(tokenSenderAccount).deposit(
-        ubtMockAddress,
         tenTokens,
         destinationAddress
       );
     });
 
     it("Should release amount of tokens based on share with equal shares", async () => {
-      await UBTContract.release(ubtMockAddress, revenue1Address);
-      await UBTContract.release(ubtMockAddress, revenue2Address);
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue1Address)
-      ).to.equal(fiveTokens);
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue2Address)
-      ).to.equal(fiveTokens);
+      await UBTContract.release(revenue1Address);
+      await UBTContract.release(revenue2Address);
+      expect(await UBTContract.ubtReleased(revenue1Address)).to.equal(
+        fiveTokens
+      );
+      expect(await UBTContract.ubtReleased(revenue2Address)).to.equal(
+        fiveTokens
+      );
     });
 
     it("Should release amount of tokens based on share with equal shares after 3rd payee is added", async () => {
       // 2 payees and 10 ubt deposited
-      await UBTContract.release(ubtMockAddress, revenue1Address);
-      await UBTContract.release(ubtMockAddress, revenue2Address);
+      await UBTContract.release(revenue1Address);
+      await UBTContract.release(revenue2Address);
       // after release they each have 5 ubt
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue1Address)
-      ).to.equal(fiveTokens);
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue2Address)
-      ).to.equal(fiveTokens);
+      expect(await UBTContract.ubtReleased(revenue1Address)).to.equal(
+        fiveTokens
+      );
+      expect(await UBTContract.ubtReleased(revenue2Address)).to.equal(
+        fiveTokens
+      );
       accounts = await ethers.getSigners();
       const revenue3Address = await accounts[3].getAddress();
 
@@ -415,28 +398,27 @@ describe("UBTSplitter contract tests", () => {
         .approve(UBTAddress, tenTokens);
       await tx.wait();
       await UBTContract.connect(tokenSenderAccount).deposit(
-        ubtMockAddress,
         tenTokens,
         destinationAddress
       );
 
       // all 3 release again
-      await UBTContract.release(ubtMockAddress, revenue1Address);
-      await UBTContract.release(ubtMockAddress, revenue2Address);
-      await UBTContract.release(ubtMockAddress, revenue3Address);
+      await UBTContract.release(revenue1Address);
+      await UBTContract.release(revenue2Address);
+      await UBTContract.release(revenue3Address);
 
       // check total released for all 3, first 2 should have 5 more than 3rd one
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue1Address)
-      ).to.equal(fiveTokens.add(threePointThreeInPeriodTokens));
+      expect(await UBTContract.ubtReleased(revenue1Address)).to.equal(
+        fiveTokens.add(threePointThreeInPeriodTokens)
+      );
 
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue2Address)
-      ).to.equal(fiveTokens.add(threePointThreeInPeriodTokens));
+      expect(await UBTContract.ubtReleased(revenue2Address)).to.equal(
+        fiveTokens.add(threePointThreeInPeriodTokens)
+      );
 
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue3Address)
-      ).to.equal(threePointThreeInPeriodTokens);
+      expect(await UBTContract.ubtReleased(revenue3Address)).to.equal(
+        threePointThreeInPeriodTokens
+      );
     });
 
     it("Should update share and release the right amount of tokens", async () => {
@@ -446,14 +428,14 @@ describe("UBTSplitter contract tests", () => {
         shares.twentyFive,
         baseledgervaloper
       );
-      await UBTContract.release(ubtMockAddress, revenue1Address);
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue1Address)
-      ).to.equal(threePointThreeInPeriodTokens);
+      await UBTContract.release(revenue1Address);
+      expect(await UBTContract.ubtReleased(revenue1Address)).to.equal(
+        threePointThreeInPeriodTokens
+      );
     });
 
     it("Should release token, update share, send new token amount and then release right amount of tokens", async () => {
-      await UBTContract.release(ubtMockAddress, revenue1Address);
+      await UBTContract.release(revenue1Address);
 
       await UBTContract.updatePayee(
         revenue1Address,
@@ -469,33 +451,32 @@ describe("UBTSplitter contract tests", () => {
         .approve(UBTAddress, tenTokens);
       await tx.wait();
       await UBTContract.connect(tokenSenderAccount).deposit(
-        ubtMockAddress,
         tenTokens,
         destinationAddress
       );
 
-      await UBTContract.release(ubtMockAddress, revenue1Address);
+      await UBTContract.release(revenue1Address);
 
       // only first one released before updatePayee was called
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue1Address)
-      ).to.equal(fiveTokens.add(fiveTokens));
-      expect(await UBTContract.ubtTotalReleased(ubtMockAddress)).to.equal(
+      expect(await UBTContract.ubtReleased(revenue1Address)).to.equal(
+        fiveTokens.add(fiveTokens)
+      );
+      expect(await UBTContract.ubtTotalReleased()).to.equal(
         fiveTokens.add(fiveTokens)
       );
     });
 
     it("Should BOTH release token, update share, send new token amount and then BOTH release right amount of tokens", async () => {
-      await UBTContract.release(ubtMockAddress, revenue1Address);
-      await UBTContract.release(ubtMockAddress, revenue2Address);
+      await UBTContract.release(revenue1Address);
+      await UBTContract.release(revenue2Address);
 
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue1Address)
-      ).to.equal(fiveTokens);
+      expect(await UBTContract.ubtReleased(revenue1Address)).to.equal(
+        fiveTokens
+      );
 
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue2Address)
-      ).to.equal(fiveTokens);
+      expect(await UBTContract.ubtReleased(revenue2Address)).to.equal(
+        fiveTokens
+      );
 
       await UBTContract.updatePayee(
         revenue1Address,
@@ -511,21 +492,18 @@ describe("UBTSplitter contract tests", () => {
         .approve(UBTAddress, tenTokens);
       await tx.wait();
       await UBTContract.connect(tokenSenderAccount).deposit(
-        ubtMockAddress,
         tenTokens,
         destinationAddress
       );
 
-      await UBTContract.release(ubtMockAddress, revenue1Address);
-      await UBTContract.release(ubtMockAddress, revenue2Address);
+      await UBTContract.release(revenue1Address);
+      await UBTContract.release(revenue2Address);
 
       // since they both released in correct order, update payee is reflected on follow up release
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue1Address)
-      ).to.equal(fiveTokens.add(threePointThreeInPeriodTokens));
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue2Address)
-      ).to.equal(
+      expect(await UBTContract.ubtReleased(revenue1Address)).to.equal(
+        fiveTokens.add(threePointThreeInPeriodTokens)
+      );
+      expect(await UBTContract.ubtReleased(revenue2Address)).to.equal(
         fiveTokens
           .add(threePointThreeInPeriodTokens)
           .add(threePointThreeInPeriodTokens)
@@ -533,7 +511,7 @@ describe("UBTSplitter contract tests", () => {
     });
 
     it("Should emit event, when release function is called", async () => {
-      expect(await UBTContract.release(ubtMockAddress, revenue1Address))
+      expect(await UBTContract.release(revenue1Address))
         .to.emit(UBTContract, "UbtPaymentReleased")
         .withArgs(ubtMockAddress, revenue1Address, stakingAddress, fiveTokens);
     });
@@ -545,16 +523,16 @@ describe("UBTSplitter contract tests", () => {
         shares.zero,
         baseledgervaloper
       );
-      await expect(
-        UBTContract.release(ubtMockAddress, revenue1Address)
-      ).to.be.revertedWith("UBTSplitter: revenueAddress has no shares");
+      await expect(UBTContract.release(revenue1Address)).to.be.revertedWith(
+        "UBTSplitter: revenueAddress has no shares"
+      );
     });
 
     it("Should fail on try to release on validator without due payment", async () => {
-      await UBTContract.release(ubtMockAddress, revenue1Address);
-      await expect(
-        UBTContract.release(ubtMockAddress, revenue1Address)
-      ).to.be.revertedWith("UBTSplitter: revenueAddress is not due payment");
+      await UBTContract.release(revenue1Address);
+      await expect(UBTContract.release(revenue1Address)).to.be.revertedWith(
+        "UBTSplitter: revenueAddress is not due payment"
+      );
     });
   });
 
@@ -580,27 +558,26 @@ describe("UBTSplitter contract tests", () => {
         .approve(UBTAddress, formatTokens("100"));
       await tx.wait();
       await UBTContract.connect(tokenSenderAccount).deposit(
-        ubtMockAddress,
         formatTokens("50"),
         destinationAddress
       );
     });
 
     it("Should release amount of tokens based on not equal shares", async () => {
-      await UBTContract.release(ubtMockAddress, revenue1Address);
-      await UBTContract.release(ubtMockAddress, revenue2Address);
+      await UBTContract.release(revenue1Address);
+      await UBTContract.release(revenue2Address);
 
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue1Address)
-      ).to.equal(formatTokens("30"));
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue2Address)
-      ).to.equal(formatTokens("20"));
+      expect(await UBTContract.ubtReleased(revenue1Address)).to.equal(
+        formatTokens("30")
+      );
+      expect(await UBTContract.ubtReleased(revenue2Address)).to.equal(
+        formatTokens("20")
+      );
     });
 
     it("Should release amount of tokens based on share with equal shares after 3rd payee is added", async () => {
-      await UBTContract.release(ubtMockAddress, revenue1Address);
-      await UBTContract.release(ubtMockAddress, revenue2Address);
+      await UBTContract.release(revenue1Address);
+      await UBTContract.release(revenue2Address);
 
       accounts = await ethers.getSigners();
       const revenue3Address = await accounts[3].getAddress();
@@ -615,30 +592,29 @@ describe("UBTSplitter contract tests", () => {
 
       // deposit 20 more ubt
       await UBTContract.connect(tokenSenderAccount).deposit(
-        ubtMockAddress,
         formatTokens("20"),
         destinationAddress
       );
 
       // all 3 release again
-      await UBTContract.release(ubtMockAddress, revenue1Address);
-      await UBTContract.release(ubtMockAddress, revenue2Address);
-      await UBTContract.release(ubtMockAddress, revenue3Address);
+      await UBTContract.release(revenue1Address);
+      await UBTContract.release(revenue2Address);
+      await UBTContract.release(revenue3Address);
 
       // first got 30 in first release, 10 in second (60 * 20 / 120)
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue1Address)
-      ).to.equal(formatTokens("40"));
+      expect(await UBTContract.ubtReleased(revenue1Address)).to.equal(
+        formatTokens("40")
+      );
 
       // second got 20 in first release, 6.6666... in second (40 * 20 / 120)
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue2Address)
-      ).to.equal(formatTokens("26.666666666666666666"));
+      expect(await UBTContract.ubtReleased(revenue2Address)).to.equal(
+        formatTokens("26.666666666666666666")
+      );
 
       // third got only 3.333... in second release (20 * 20 / 120)
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue3Address)
-      ).to.equal(threePointThreeInPeriodTokens);
+      expect(await UBTContract.ubtReleased(revenue3Address)).to.equal(
+        threePointThreeInPeriodTokens
+      );
     });
 
     it("Should update share and release the right amount of tokens after 2 deposits", async () => {
@@ -649,46 +625,45 @@ describe("UBTSplitter contract tests", () => {
         shares.twenty,
         baseledgervaloper
       );
-      await UBTContract.release(ubtMockAddress, revenue1Address);
-      await UBTContract.release(ubtMockAddress, revenue2Address);
+      await UBTContract.release(revenue1Address);
+      await UBTContract.release(revenue2Address);
 
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue1Address)
-      ).to.equal(formatTokens("37.5"));
+      expect(await UBTContract.ubtReleased(revenue1Address)).to.equal(
+        formatTokens("37.5")
+      );
 
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue2Address)
-      ).to.equal(formatTokens("12.5"));
+      expect(await UBTContract.ubtReleased(revenue2Address)).to.equal(
+        formatTokens("12.5")
+      );
 
       // deposit 20 more ubt and release again to make sure those 20 are correctly split as well
       await UBTContract.connect(tokenSenderAccount).deposit(
-        ubtMockAddress,
         formatTokens("20"),
         destinationAddress
       );
 
-      await UBTContract.release(ubtMockAddress, revenue1Address);
-      await UBTContract.release(ubtMockAddress, revenue2Address);
+      await UBTContract.release(revenue1Address);
+      await UBTContract.release(revenue2Address);
 
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue1Address)
-      ).to.equal(formatTokens("52.5"));
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue2Address)
-      ).to.equal(formatTokens("17.5"));
+      expect(await UBTContract.ubtReleased(revenue1Address)).to.equal(
+        formatTokens("52.5")
+      );
+      expect(await UBTContract.ubtReleased(revenue2Address)).to.equal(
+        formatTokens("17.5")
+      );
     });
 
     it("Should release token, update share, send new token amount and then release right amount of tokens", async () => {
       // only first one release and then update happens before 2nd one releases, 50 deposited
-      await UBTContract.release(ubtMockAddress, revenue1Address);
+      await UBTContract.release(revenue1Address);
 
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue1Address)
-      ).to.equal(formatTokens("30"));
+      expect(await UBTContract.ubtReleased(revenue1Address)).to.equal(
+        formatTokens("30")
+      );
 
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue2Address)
-      ).to.equal(formatTokens("0"));
+      expect(await UBTContract.ubtReleased(revenue2Address)).to.equal(
+        formatTokens("0")
+      );
 
       await UBTContract.updatePayee(
         revenue2Address,
@@ -699,40 +674,39 @@ describe("UBTSplitter contract tests", () => {
 
       // deposit 20 more ubt and release again
       await UBTContract.connect(tokenSenderAccount).deposit(
-        ubtMockAddress,
         formatTokens("20"),
         destinationAddress
       );
 
-      await UBTContract.release(ubtMockAddress, revenue1Address);
-      await UBTContract.release(ubtMockAddress, revenue2Address);
+      await UBTContract.release(revenue1Address);
+      await UBTContract.release(revenue2Address);
 
       // because only first released before update, 20 unreleased ubts remained,
       // so now 40 ubts are splitted with 60/25 shares
 
       // 30 + 60 * 40 / 85
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue1Address)
-      ).to.equal(formatTokens("58.235294117647058823"));
+      expect(await UBTContract.ubtReleased(revenue1Address)).to.equal(
+        formatTokens("58.235294117647058823")
+      );
 
       // 0 + 25 * 40 / 85
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue2Address)
-      ).to.equal(formatTokens("11.764705882352941176"));
+      expect(await UBTContract.ubtReleased(revenue2Address)).to.equal(
+        formatTokens("11.764705882352941176")
+      );
     });
 
     it("Should BOTH release token, update share, send new token amount and then BOTH release right amount of tokens", async () => {
       // both releases, 50 deposited, 60/40 shares
-      await UBTContract.release(ubtMockAddress, revenue1Address);
-      await UBTContract.release(ubtMockAddress, revenue2Address);
+      await UBTContract.release(revenue1Address);
+      await UBTContract.release(revenue2Address);
 
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue1Address)
-      ).to.equal(formatTokens("30"));
+      expect(await UBTContract.ubtReleased(revenue1Address)).to.equal(
+        formatTokens("30")
+      );
 
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue2Address)
-      ).to.equal(formatTokens("20"));
+      expect(await UBTContract.ubtReleased(revenue2Address)).to.equal(
+        formatTokens("20")
+      );
 
       await UBTContract.updatePayee(
         revenue2Address,
@@ -743,25 +717,24 @@ describe("UBTSplitter contract tests", () => {
 
       // deposit 20 more ubt and release again
       await UBTContract.connect(tokenSenderAccount).deposit(
-        ubtMockAddress,
         formatTokens("20"),
         destinationAddress
       );
 
-      await UBTContract.release(ubtMockAddress, revenue1Address);
-      await UBTContract.release(ubtMockAddress, revenue2Address);
+      await UBTContract.release(revenue1Address);
+      await UBTContract.release(revenue2Address);
 
       // both released, now only 20 deposited are split according to new shares 60/25
 
       // 30 + 60 * 20 / 85
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue1Address)
-      ).to.equal(formatTokens("44.117647058823529411"));
+      expect(await UBTContract.ubtReleased(revenue1Address)).to.equal(
+        formatTokens("44.117647058823529411")
+      );
 
       // 20 + 25 * 20 / 85
-      expect(
-        await UBTContract.ubtReleased(ubtMockAddress, revenue2Address)
-      ).to.equal(formatTokens("25.882352941176470588"));
+      expect(await UBTContract.ubtReleased(revenue2Address)).to.equal(
+        formatTokens("25.882352941176470588")
+      );
     });
   });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,6 +1,6 @@
 import hre, { ethers } from "hardhat";
 import { expect } from "chai";
-import { UBTSplitter, UBTMock } from "../typechain";
+import { BaseledgerUBTSplitter, UBTMock } from "../typechain";
 import { ContractFactory } from "@ethersproject/contracts";
 import {
   tenTokens,
@@ -14,8 +14,8 @@ import {
 } from "./utils";
 import { Signer } from "ethers";
 
-describe("UBTSplitter contract tests", () => {
-  let UBTContract: UBTSplitter;
+describe("BaseledgerUBTSplitter contract tests", () => {
+  let UBTContract: BaseledgerUBTSplitter;
   let ubtMock: UBTMock;
   let UBTAddress: string;
   let ubtMockAddress: string;
@@ -54,7 +54,7 @@ describe("UBTSplitter contract tests", () => {
 
   beforeEach(async () => {
     const UBTFactory: ContractFactory = await hre.ethers.getContractFactory(
-      "UBTSplitter"
+      "BaseledgerUBTSplitter"
     );
     const ubtMockFactory: ContractFactory = await hre.ethers.getContractFactory(
       "UBTMock"
@@ -62,7 +62,9 @@ describe("UBTSplitter contract tests", () => {
     ubtMock = (await ubtMockFactory.deploy()) as UBTMock;
     await ubtMock.deployed();
     ubtMockAddress = ubtMock.address;
-    UBTContract = (await UBTFactory.deploy(ubtMockAddress)) as UBTSplitter;
+    UBTContract = (await UBTFactory.deploy(
+      ubtMockAddress
+    )) as BaseledgerUBTSplitter;
     await UBTContract.deployed();
     UBTAddress = UBTContract.address;
     // Transfer tokens to account which will make a deposit to the contract through deposit
@@ -717,7 +719,7 @@ describe("UBTSplitter contract tests", () => {
         destinationAddress
       );
 
-      expect(await UBTContract.ubtNotReleasedInLastPeriods()).to.equal(
+      expect(await UBTContract.ubtNotReleasedInPreviousPeriods()).to.equal(
         formatTokens("20")
       );
 
@@ -763,7 +765,7 @@ describe("UBTSplitter contract tests", () => {
         destinationAddress
       );
 
-      expect(await UBTContract.ubtNotReleasedInLastPeriods()).to.equal(
+      expect(await UBTContract.ubtNotReleasedInPreviousPeriods()).to.equal(
         formatTokens("20")
       );
 
@@ -815,7 +817,7 @@ describe("UBTSplitter contract tests", () => {
         destinationAddress
       );
 
-      expect(await UBTContract.ubtNotReleasedInLastPeriods()).to.equal(
+      expect(await UBTContract.ubtNotReleasedInPreviousPeriods()).to.equal(
         formatTokens("20")
       );
 
@@ -841,7 +843,7 @@ describe("UBTSplitter contract tests", () => {
       );
 
       // 40 - 19.2 - 12.8
-      expect(await UBTContract.ubtNotReleasedInLastPeriods()).to.equal(
+      expect(await UBTContract.ubtNotReleasedInPreviousPeriods()).to.equal(
         formatTokens("8")
       );
 
@@ -880,7 +882,7 @@ describe("UBTSplitter contract tests", () => {
         destinationAddress
       );
 
-      expect(await UBTContract.ubtNotReleasedInLastPeriods()).to.equal(
+      expect(await UBTContract.ubtNotReleasedInPreviousPeriods()).to.equal(
         formatTokens("0")
       );
 
@@ -926,7 +928,7 @@ describe("UBTSplitter contract tests", () => {
         destinationAddress
       );
 
-      expect(await UBTContract.ubtNotReleasedInLastPeriods()).to.equal(
+      expect(await UBTContract.ubtNotReleasedInPreviousPeriods()).to.equal(
         formatTokens("0")
       );
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -112,7 +112,7 @@ describe("UBTSplitter contract tests", () => {
           zeroToken,
           destinationAddress
         )
-      ).to.be.revertedWith("amount should be grater than zero");
+      ).to.be.revertedWith("amount should be greater than zero");
     });
   });
 
@@ -388,9 +388,21 @@ describe("UBTSplitter contract tests", () => {
       );
     });
 
-    it("Should not release if sender has no shares", async () => {
+    it("Should not release if sender is not payee", async () => {
       await expect(
         UBTContract.connect(maliciousAccount).release()
+      ).to.be.revertedWith("msg.sender is not payee");
+    });
+
+    it("Should not release if sender has no shares", async () => {
+      await UBTContract.updatePayee(
+        revenue1Address,
+        stakingAddress,
+        shares.zero,
+        baseledgervaloper
+      );
+      await expect(
+        UBTContract.connect(revenue1Account).release()
       ).to.be.revertedWith("msg.sender has no shares");
     });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -24,6 +24,7 @@ describe("UBTSplitter contract tests", () => {
   let revenue2Address: string;
   let stakingAddress: string;
   let maliciousAccount: Signer;
+  let nonExistentPayee: string;
   let tokenSenderAccount: Signer;
   let tokenSenderAddress: string;
   const baseledgervaloper = "Testing String";
@@ -36,6 +37,7 @@ describe("UBTSplitter contract tests", () => {
     revenue1Address = await accounts[0].getAddress();
     revenue2Address = await accounts[1].getAddress();
     stakingAddress = await accounts[2].getAddress();
+    nonExistentPayee = await accounts[5].getAddress();
 
     tokenSenderAccount = await accounts[3];
     tokenSenderAddress = await accounts[3].getAddress();
@@ -95,7 +97,7 @@ describe("UBTSplitter contract tests", () => {
     it("Should fail on transfer token with empty token destination address", async () => {
       await expect(
         UBTContract.connect(tokenSenderAccount).deposit(tenTokens, "")
-      ).to.be.revertedWith("UBTSplitter: String is empty");
+      ).to.be.revertedWith("string is empty");
     });
 
     it("Should fail on transfer zero token amount", async () => {
@@ -104,7 +106,7 @@ describe("UBTSplitter contract tests", () => {
           zeroToken,
           destinationAddress
         )
-      ).to.be.revertedWith("UBTSplitter: amount should be grater than zero");
+      ).to.be.revertedWith("amount should be grater than zero");
     });
   });
 
@@ -130,7 +132,7 @@ describe("UBTSplitter contract tests", () => {
           depositNonce,
           timestamp
         );
-      expect(await UBTContract.payees(0)).to.equal(revenue1Address);
+      expect(await UBTContract.payees(revenue1Address)).to.equal(true);
       expect(await UBTContract.shares(revenue1Address)).to.equal(shares.fifty);
       expect(await UBTContract.totalShares()).to.equal(shares.fifty);
     });
@@ -159,7 +161,7 @@ describe("UBTSplitter contract tests", () => {
           shares.fifty,
           baseledgervaloper
         )
-      ).to.be.revertedWith("UBTSplitter: Address is zero address");
+      ).to.be.revertedWith("address is zero address");
     });
 
     it("Should fail on add validator with zero stakingAddress address", async () => {
@@ -170,7 +172,7 @@ describe("UBTSplitter contract tests", () => {
           shares.fifty,
           baseledgervaloper
         )
-      ).to.be.revertedWith("UBTSplitter: Address is zero address");
+      ).to.be.revertedWith("address is zero address");
     });
 
     it("Should fail on add validator with zero share", async () => {
@@ -181,13 +183,13 @@ describe("UBTSplitter contract tests", () => {
           shares.zero,
           baseledgervaloper
         )
-      ).to.be.revertedWith("UBTSplitter: shares are 0");
+      ).to.be.revertedWith("shares are 0");
     });
 
     it("Should fail on add validator with empty baseledgervaloper string", async () => {
       await expect(
         UBTContract.addPayee(revenue1Address, stakingAddress, shares.fifty, "")
-      ).to.be.revertedWith("UBTSplitter: String is empty");
+      ).to.be.revertedWith("string is empty");
     });
 
     it("Should fail on add validator with already allocated share", async () => {
@@ -204,7 +206,7 @@ describe("UBTSplitter contract tests", () => {
           shares.fifty,
           baseledgervaloper
         )
-      ).to.be.revertedWith("UBTSplitter: revenueAddress already has shares");
+      ).to.be.revertedWith("revenueAddress already has shares");
     });
 
     it("Should fail if malicious account tries to add validator ", async () => {
@@ -255,8 +257,8 @@ describe("UBTSplitter contract tests", () => {
           depositNonce,
           timestamp
         );
-      expect(await UBTContract.payees(0)).to.equal(revenue1Address);
-      expect(await UBTContract.payees(1)).to.equal(revenue2Address);
+      expect(await UBTContract.payees(revenue1Address)).to.equal(true);
+      expect(await UBTContract.payees(revenue2Address)).to.equal(true);
       expect(await UBTContract.shares(revenue1Address)).to.equal(
         shares.hundred
       );
@@ -297,7 +299,7 @@ describe("UBTSplitter contract tests", () => {
           shares.fifty,
           baseledgervaloper
         )
-      ).to.be.revertedWith("UBTSplitter: Address is zero address");
+      ).to.be.revertedWith("address is zero address");
     });
 
     it("Should fail on update validator with zero staking address", async () => {
@@ -308,7 +310,7 @@ describe("UBTSplitter contract tests", () => {
           shares.fifty,
           baseledgervaloper
         )
-      ).to.be.revertedWith("UBTSplitter: Address is zero address");
+      ).to.be.revertedWith("address is zero address");
     });
 
     it("Should fail on update validator with empty baseledgervaloper string", async () => {
@@ -319,7 +321,7 @@ describe("UBTSplitter contract tests", () => {
           shares.fifty,
           ""
         )
-      ).to.be.revertedWith("UBTSplitter: String is empty");
+      ).to.be.revertedWith("string is empty");
     });
 
     it("Should fail if malicious account tries to update validator ", async () => {
@@ -331,6 +333,17 @@ describe("UBTSplitter contract tests", () => {
           baseledgervaloper
         )
       ).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+
+    it("Should fail if payee does not exist", async () => {
+      await expect(
+        UBTContract.updatePayee(
+          nonExistentPayee,
+          stakingAddress,
+          shares.fifty,
+          baseledgervaloper
+        )
+      ).to.be.revertedWith("payee does not exist");
     });
   });
 
@@ -524,14 +537,14 @@ describe("UBTSplitter contract tests", () => {
         baseledgervaloper
       );
       await expect(UBTContract.release(revenue1Address)).to.be.revertedWith(
-        "UBTSplitter: revenueAddress has no shares"
+        "revenueAddress has no shares"
       );
     });
 
     it("Should fail on try to release on validator without due payment", async () => {
       await UBTContract.release(revenue1Address);
       await expect(UBTContract.release(revenue1Address)).to.be.revertedWith(
-        "UBTSplitter: revenueAddress is not due payment"
+        "revenueAddress is not due payment"
       );
     });
   });


### PR DESCRIPTION
This PR fixes comments from https://github.com/Baseledger/baseledger-contracts/pull/5 and it is targeting that branch, I started new branch to make review easier.
Things that are changed are (all changes are followed with either new or updated test) - maybe it is easier to review commit by commit, but here is a summary:

1. renaming according to comments
2. removing token from argument in functions because contract will be used for ubt only, removing whitelist related fields
3. fixed warnings that required message was too long
i was not sure about this one, but i found some audit (https://unslashed.finance/audit-2.pdf) that says that ideally require message should be less than 32bytes (page 10) Since removing UbtSplitter prefix of require messages fixed warnings i went for that, but can revert if needed
4. add check on add/update payee that check if payee was set, before update worked even if payee was not added previosly
to make this work i switched from array to address => bool mapping for payees to make these checks easier
5. adapted release function so that msg.sender releases funds, before revenueAddress was passed in as an argument
6. moved common logic of add/update payee to separate private function
7. adapted docs a bit to reflect changes
8. removed usage of safeERC20
not sure about this one but it seems like for ubt it should be good to remove (https://etherscan.io/address/0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e#code)


